### PR TITLE
Micro optimisations

### DIFF
--- a/src/ClientBridge.lua
+++ b/src/ClientBridge.lua
@@ -40,7 +40,7 @@ function ClientBridge._start(config)
 	RunService.Heartbeat:Connect(function()
 		debug.profilebegin("ClientBridge")
 
-		if (os.clock() - lastSend) > rateManager.GetSendRate() then
+		if (time() - lastSend) > rateManager.GetSendRate() then
 			local toSend = {}
 			for _, v in ipairs(SendQueue) do
 				local tbl = {}
@@ -57,7 +57,7 @@ function ClientBridge._start(config)
 			SendQueue = {}
 		end
 
-		if (os.clock() - lastReceive) > rateManager.GetReceiveRate() then
+		if (time() - lastReceive) > rateManager.GetReceiveRate() then
 			for _, v in ipairs(ReceiveQueue) do
 				local remoteName = serdeLayer.WhatIsThis(v.remote, "id")
 				if BridgeObjects[remoteName] == nil then

--- a/src/ServerBridge.lua
+++ b/src/ServerBridge.lua
@@ -234,7 +234,7 @@ end
 ]=]
 function ServerBridge:FireToAllExcept(blacklistedPlrs: Player | { Player }, ...: any): { Player }
 	local toSend = {}
-	for _, v: Player in pairs(game:GetService("Players"):GetPlayers()) do
+	for _, v: Player in ipairs(game:GetService("Players"):GetPlayers()) do
 		if typeof(blacklistedPlrs) == "table" then
 			if table.find(blacklistedPlrs, v) then
 				continue
@@ -288,7 +288,7 @@ function ServerBridge:FireAllInRangeExcept(
 	...: any
 )
 	local toSend = {}
-	for _, v: Player in pairs(game:GetService("Players"):GetPlayers()) do
+	for _, v: Player in ipairs(game:GetService("Players"):GetPlayers()) do
 		if v:DistanceFromCharacter(point) <= range then
 			if typeof(blacklistedPlrs) == "table" then
 				if table.find(blacklistedPlrs, v) then
@@ -337,7 +337,7 @@ end
 ]=]
 function ServerBridge:FireAllInRange(point: Vector3, range: number, ...: any): { Player }
 	local toSend = {}
-	for _, v: Player in pairs(game:GetService("Players"):GetPlayers()) do
+	for _, v: Player in ipairs(game:GetService("Players"):GetPlayers()) do
 		if v:DistanceFromCharacter(point) <= range then
 			table.insert(toSend, v)
 		end

--- a/src/ServerBridge.lua
+++ b/src/ServerBridge.lua
@@ -59,16 +59,16 @@ function ServerBridge._start(config: config): nil
 		local sendRate = rateManager.GetSendRate()
 		local receiveRate = rateManager.GetReceiveRate()
 
-		--[[if (os.clock() - lastClear) > 60 then
-			lastClear = os.clock()
+		--[[if (time() - lastClear) > 60 then
+			lastClear = time()
 
 			for _, v in ipairs(BridgeObjects) do
 				v._rateInThisMinute = 0
 			end
 		end]]
 
-		if (os.clock() - lastSend) >= sendRate then
-			lastSend = os.clock()
+		if (time() - lastSend) >= sendRate then
+			lastSend = time()
 
 			local toSendAll = {}
 			local toSendPlayers = {}
@@ -114,8 +114,8 @@ function ServerBridge._start(config: config): nil
 			SendQueue = {}
 		end
 
-		if (os.clock() - lastReceive) >= receiveRate then
-			lastReceive = os.clock()
+		if (time() - lastReceive) >= receiveRate then
+			lastReceive = time()
 
 			for _, v in ipairs(ReceiveQueue) do
 				local obj = BridgeObjects[serdeLayer.WhatIsThis(v.remote, "id")]

--- a/src/serdeLayer.lua
+++ b/src/serdeLayer.lua
@@ -33,7 +33,7 @@ end
 function serdeLayer._start()
 	if RunService:IsClient() then
 		AutoSerde = ReplicatedStorage:WaitForChild("AutoSerde")
-		for _, v in pairs(AutoSerde:GetChildren()) do
+		for _, v in ipairs(AutoSerde:GetChildren()) do
 			local strValue = v :: StringValue
 			sendDict[strValue.Name] = strValue.Value
 			receiveDict[strValue.Value] = strValue.Name

--- a/src/serdeLayer.lua
+++ b/src/serdeLayer.lua
@@ -19,15 +19,15 @@ local AutoSerde: Folder = nil
 type toSend = string
 
 local function fromHex(toConvert: string): string
-	return (toConvert:gsub("..", function(cc)
+	return string.gsub(toConvert, "..", function(cc)
 		return string.char(tonumber(cc, 16))
-	end))
+	end)
 end
 
 local function toHex(toConvert: string): string
-	return (toConvert:gsub(".", function(c)
+	return string.gsub(toConvert, ".", function(c)
 		return string.format("%02X", string.byte(c))
-	end))
+	end)
 end
 
 function serdeLayer._start()
@@ -147,7 +147,7 @@ end
 	@return string
 ]=]
 function serdeLayer.CreateUUID()
-	return HttpService:GenerateGUID(false):gsub("-", "")
+	return string.gsub(HttpService:GenerateGUID(false), "-", "")
 end
 
 --[=[
@@ -198,7 +198,7 @@ function serdeLayer.DictionaryToTable(dict: { [string]: any })
 	end
 
 	table.sort(keys, function(a, b)
-		return a:lower() < b:lower()
+		return string.lower(a) < string.lower(b)
 	end)
 	local toReturn = {}
 	for _, v in ipairs(keys) do


### PR DESCRIPTION
ipairs is objectively better than pairs on an array I changed it in any occurrences I found,


changed the string methods to make use of the [Specialized builtin function calls](https://luau-lang.org/performance#specialized-builtin-function-calls) optimisation
![image](https://user-images.githubusercontent.com/68239467/184018047-30d5ef5e-e986-4ee7-bb5d-21b8c3202b9b.png)
![image](https://user-images.githubusercontent.com/68239467/184017946-c67f428b-31d3-4280-84a7-78d0dce21f79.png)


changed os.clock() to time()
time() has the same resolution as os.clock (1us) os.clock should be used to benchmark where time() can be used for anything else

![image](https://user-images.githubusercontent.com/68239467/184018509-f6dc251f-a08d-4b45-b409-689e6aa0b55b.png)



tl;dr it maintains the same functionality just a bit faster