### PR TITLE
Improve DictionaryToTable type annotation

### DIFF
--- a/src/SerdesLayer.d.ts
+++ b/src/SerdesLayer.d.ts
@@ -5,7 +5,7 @@ declare namespace serdeLayer {
 	export type PackUUID = (uuid: string) => string
 	export type UnpackUUID = (packedUUID: string) => string
 	
-	export type DictionaryToTable = ({unknown}) => {any}
+	export type DictionaryToTable = <A extends any>(dict: {[index: string]: A}) => {[index: number]: A}
 }
 
 export = serdeLayer


### PR DESCRIPTION
Improved type definition for **DictionaryToTable** that represents better the inputs/outputs of the function. Note that `Array<>` is not recognized as an interface in the package for some reason, but `{[index: number]: A}` basically means the same.

As I saw, this was already patched in **v2.0.0**, but in older versions (latest available version for roblox-ts: 1.9.10) an incorrect type annotation for **DictionaryToTable** causes the compiler to error. In any case, this type annotation should be better than just marking `unknown` as the input.