### PR TITLE
Improve DictionaryToTable type annotation

### DIFF
--- a/src/SerdesLayer.d.ts
+++ b/src/SerdesLayer.d.ts
@@ -5,7 +5,7 @@ declare namespace serdeLayer {
 	export type PackUUID = (uuid: string) => string
 	export type UnpackUUID = (packedUUID: string) => string
 	
-	export type DictionaryToTable = ({unknown}) => {any}
+	export type DictionaryToTable = <A extends any>(dict: {[index: string]: A}) => Array<A>
 }
 
 export = serdeLayer


### PR DESCRIPTION
Improved type annotation for **DictionaryToTable** that represents inputs/outputs of the function accurately.

As I saw, this was already patched in **v2.0.0** by specifying `unknown` as the input, which is not the best solution at all, but in older versions (latest available version for roblox-ts: **v1.9.10**) an incorrect type annotation for DictionaryToTable causes the compiler to error.